### PR TITLE
Correct README example to access UIBezierPath's CGPath property instead of relying on an implicit cast

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It is completely configurable **and animatable**, so you can have custom drawn v
 ``` objc
 CKShapeView *pieView = [[CKShapeView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
 CGFloat width = CGRectGetWidth(pieView.bounds);
-pieView.path = [UIBezierPath bezierPathWithOvalInRect:CGRectInset(pieView.bounds, width/4, width/4)];
+pieView.path = [UIBezierPath bezierPathWithOvalInRect:CGRectInset(pieView.bounds, width/4, width/4)].CGPath;
 pieView.lineWidth = width/2;
 pieView.fillColor = nil;
 pieView.strokeColor = [UIColor blackColor];


### PR DESCRIPTION
Using ARC, the compiler complains that the implicit conversion of a UIBezierPath to a CGPathRef requires a bridged cast. Access the UIBezierPath's CGPath instead.
