### PR TITLE
Getter method "path" will now return the path object.

### DIFF
--- a/CKShapeView/CKShapeView.m
+++ b/CKShapeView/CKShapeView.m
@@ -116,6 +116,8 @@
     }
 
     [path setLineDash:pattern count:count phase:phase];
+    
+    return path;
 }
 
 - (void)setFillColor:(UIColor *)fillColor {


### PR DESCRIPTION
Fixed "Control reaches end of non-void function" warning.
