### PR TITLE
Changed actionForLayer key

### DIFF
--- a/CKShapeView/CKShapeView.m
+++ b/CKShapeView/CKShapeView.m
@@ -152,7 +152,7 @@
 
     if ([layer isEqual:self.layer] && [[NSNull null] isEqual:action]) {
         if ([self shouldForwardSelector:NSSelectorFromString(key)]) {
-            CABasicAnimation *animation = (CABasicAnimation *)[self actionForLayer:layer forKey:@"bounds"];
+            CABasicAnimation *animation = (CABasicAnimation *)[self actionForLayer:layer forKey:@"backgroundColor"];
             if ([animation isKindOfClass:[CABasicAnimation class]]) {
                 animation.fromValue = [layer valueForKey:key];
                 animation.keyPath = key;


### PR DESCRIPTION
bounds no longer uses CABasicAnimation and causes issues.

For instance, in my app it causes touches to not be registered after changing the stroke color from an animation block.