### PR TITLE
Release update on CocoaPods

### DIFF
--- a/CKShapeView.podspec
+++ b/CKShapeView.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name     = 'CKShapeView'
-  s.version  = '0.1.2'
+  s.version  = '0.1.3'
   s.license  = 'MIT'
   s.summary  = 'UIView subclass that is backed by CAShapeLayer'
   s.homepage = 'https://github.com/conradev/CKShapeView'
   s.author   = { 'Conrad Kramer' => 'conrad@kramerapps.com' }
   s.source   = { :git => 'https://github.com/conradev/CKShapeView.git',
-                 :tag => '0.1.2' }
+                 :tag => '0.1.3' }
   s.source_files = 'CKShapeView'
   s.requires_arc = true
   s.platform = :ios, '3.0'


### PR DESCRIPTION
Could you update the version on CocoaPods to include the change from `bounds` to `backgroundColor` so I don’t have to point to the master? Thanks :smile: 
