### PR TITLE
Update 3 parameter types for better Swift compatibility

### DIFF
--- a/CKShapeView/CKShapeView.h
+++ b/CKShapeView/CKShapeView.h
@@ -16,7 +16,7 @@
 
 @property UIColor *fillColor;
 
-@property (copy) NSString *fillRule;
+@property (copy) CAShapeLayerFillRule *fillRule;
 
 @property UIColor *strokeColor;
 
@@ -26,9 +26,9 @@
 
 @property CGFloat miterLimit;
 
-@property (copy) NSString *lineCap;
+@property (copy) CAShapeLayerLineCap *lineCap;
 
-@property (copy) NSString *lineJoin;
+@property (copy) CAShapeLayerLineJoin *lineJoin;
 
 @property CGFloat lineDashPhase;
 


### PR DESCRIPTION
This might be a naive fix but it fixed issues I was having with Swift 4.2 compilation. 